### PR TITLE
fix: added support for component test files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,12 +122,12 @@ function findTestQueries(source, options = {}) {
 
   try {
     ast = babel.parse(source, {
-      plugins: ['typescript'],
+      plugins: ['typescript', 'jsx'],
       sourceType: 'script',
     })
   } catch (e) {
     ast = babel.parse(source, {
-      plugins: ['typescript'],
+      plugins: ['typescript', 'jsx'],
       sourceType: 'module',
     })
   }


### PR DESCRIPTION
## Add jsx plugin to Babel parser to fix find-ids command for component tests

Reproducible issue: https://github.com/muratkeremozcan/tour-of-heroes-react-vite-cypress-ts/pull/601
There is no support for componet test files



This PR fixes an issue where the find-ids command was not detecting test IDs in .cy.tsx component test files due to a missing Babel plugin for JSX. The key changes include:

* Added the jsx plugin to the Babel parser configuration in the findTestQueries function.
* Ensured proper parsing of .tsx files containing JSX syntax.
* As a result, the `npx find-ids --specs 'src/**/*.cy.tsx' --command getByCy,getByCyLike` command now successfully detects 34 test IDs across 22 component test specs, resolving the previous parsing issue.

<img width="729" alt="image" src="https://github.com/user-attachments/assets/ec3055cf-316f-4f9d-ba67-ce70acb2364f">
